### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/releases.yaml
+++ b/.github/workflows/releases.yaml
@@ -1,5 +1,7 @@
 ---
 name: Release
+permissions:
+  contents: read
 
 # Do this on every push
 on:
@@ -115,6 +117,8 @@ jobs:
     name: Create a new release
     runs-on: ubuntu-latest
     needs: [build-linux-x86_64-release, build-macos-x86_64-release, build-macos-arm64-release]
+    permissions:
+      contents: write
     steps:      
       - name: Download all artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/giant-squid/security/code-scanning/9](https://github.com/MWATelescope/giant-squid/security/code-scanning/9)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow. The minimal safe setting for this workflow, which only checks out code, builds, uploads/downloads artifacts, creates GitHub releases, and publishes to crates.io via a separate token, is `contents: read` at the workflow root. You can then locally elevate permissions only where needed (e.g., for the `create-release` job, which must write releases).

Concretely, in `.github/workflows/releases.yaml`:

1. Add a top-level `permissions:` block after the `name: Release` line to set default permissions for all jobs to read-only:
   ```yaml
   permissions:
     contents: read
   ```
   This satisfies CodeQL’s requirement and limits the token in all jobs by default.

2. For the `create-release` job, which uses `gh release create` to create a GitHub release, explicitly override permissions to allow writing releases (and reading contents). Add a `permissions:` block under `create-release:`:
   ```yaml
   create-release:
     name: Create a new release
     runs-on: ubuntu-latest
     needs: [...]
     permissions:
       contents: read
       contents: write
   ```
   However, YAML keys must be unique; instead, use:
   ```yaml
   permissions:
     contents: write
   ```
   because `contents: write` implies read as well. This gives that job enough privilege to create a release while leaving other jobs with only read access.

No new imports, methods, or external dependencies are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
