### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,6 +6,9 @@ on:
       - "**"
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   MWA_ASVO_API_KEY: ${{ secrets.MWA_ASVO_API_KEY }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/giant-squid/security/code-scanning/3](https://github.com/MWATelescope/giant-squid/security/code-scanning/3)

In general, the fix is to explicitly specify a minimal `permissions` block for the workflow or for the `coverage` job so that `GITHUB_TOKEN` has only the privileges required. This documents the intent and prevents accidental elevation if repository defaults change.

The single best fix here is to add a workflow‑level `permissions` block with `contents: read`, since the job only checks out code and does not need to write to the repository or other resources. Codecov uses its own token (`secrets.CODECOV_TOKEN`) and not `GITHUB_TOKEN`, so it does not require additional GitHub token scopes. Concretely, in `.github/workflows/coverage.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top, after the `on:` block (lines 1–7) and before `env:` (line 9). This will apply to all jobs in this workflow, including `coverage`, and satisfy the CodeQL rule without changing existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
