### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 on: [push, pull_request]
 
 name: Docker Multiplatform
+permissions:
+  contents: read
 
 env:
   REGISTRY_IMAGE: mwatelescope/giant-squid


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/giant-squid/security/code-scanning/2](https://github.com/MWATelescope/giant-squid/security/code-scanning/2)

In general, the fix is to add an explicit `permissions:` block that limits `GITHUB_TOKEN` to the least privileges required. Since this workflow only builds and pushes Docker images to Docker Hub (using `secrets`) and uploads/downloads artifacts, it does not need `write` access to GitHub repository contents, issues, or pull requests. The safest minimal choice is to set `permissions: contents: read` at the workflow root so it applies to all jobs, unless a job needs more.

The single best fix here is to add a root-level `permissions:` block right after the `name: Docker Multiplatform` line (line 3). This keeps the change small and affects both `build` and `merge` jobs without altering their behavior. We’ll set `contents: read`, which is adequate for common implicit uses (e.g., certain actions that might query repository metadata) while avoiding write permissions. No additional methods, imports, or definitions are required; this is purely a YAML configuration change within `.github/workflows/docker.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
