### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,5 +1,7 @@
 ---
 name: Cross-platform tests
+permissions:
+  contents: read
 
 # Do this on every push, except tags
 


### PR DESCRIPTION
Potential fix for [https://github.com/MWATelescope/giant-squid/security/code-scanning/1](https://github.com/MWATelescope/giant-squid/security/code-scanning/1)

To fix the problem, add an explicit `permissions:` block limiting the `GITHUB_TOKEN` to read-only (or the minimal required scope) either at the workflow level (applies to all jobs) or specifically for the `test` job. Since this workflow only checks out code and runs tests, it only needs read access to repository contents; `contents: read` is sufficient and matches the minimal starting point suggested by CodeQL.

The best fix without changing existing functionality is to add a workflow-level `permissions` block right after the `name:` declaration. This will apply to all current and future jobs unless they override it, documenting the intended minimal privileges and ensuring they remain restricted even if repository defaults change. Concretely, in `.github/workflows/run-tests.yaml`, insert:

```yaml
permissions:
  contents: read
```

after line 2 (`name: Cross-platform tests`). No imports or additional methods are needed because this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
